### PR TITLE
Bug Fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="sqlalchemy_validation",
-    version="0.2.0a0",
+    version="0.3.1a0",
     packages=["sqlalchemy_validation"],
 
     # Project uses reStructuredText, so ensure that the docutils get

--- a/sqlalchemy_validation/error.py
+++ b/sqlalchemy_validation/error.py
@@ -15,7 +15,11 @@ class ValidationError(UserDict, BaseValidationError):
     key: A tuple of column names.
     value: A BaseValidationError instance.
     """
-    pass
+
+    def __init__(self):
+        """
+        """
+        pass
 
 
 class ValidatesError(BaseValidationError):


### PR DESCRIPTION
Modify the __init__ method of the sqlalchemy_validation.ValidationError in order not to raise the TypeError.
The __init__ method of the sqlalchemy_validation.ValidationError doesn't take any arguments.